### PR TITLE
ci: GitHub Actions Node 24 runtime 전환 / upgrade official actions to v6

### DIFF
--- a/.github/workflows/ci-cd-ec2-compose.yml
+++ b/.github/workflows/ci-cd-ec2-compose.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -87,7 +87,7 @@ jobs:
           echo "deploy_target=$DEPLOY_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Checkout backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.BACKEND_REPO }}
           ref: ${{ steps.vars.outputs.backend_ref }}
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare SSH key
         shell: bash
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare SSH key
         shell: bash

--- a/.github/workflows/ci-cd-ecs.yml
+++ b/.github/workflows/ci-cd-ecs.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -170,7 +170,7 @@ jobs:
           echo "ecs_backend_container_name=$ECS_BACKEND_CONTAINER_NAME_VALUE" >> "$GITHUB_OUTPUT"
 
       - name: Checkout backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.BACKEND_REPO }}
           ref: ${{ steps.vars.outputs.backend_ref }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/deploy-ec2-compose-self-hosted.yml
+++ b/.github/workflows/deploy-ec2-compose-self-hosted.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -87,7 +87,7 @@ jobs:
           echo "deploy_target=$DEPLOY_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Checkout backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.BACKEND_REPO }}
           ref: ${{ steps.vars.outputs.backend_ref }}
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify docker runtime
         run: |
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify docker runtime
         run: |

--- a/.github/workflows/deploy-ec2-compose.yml
+++ b/.github/workflows/deploy-ec2-compose.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare SSH key
         shell: bash

--- a/.github/workflows/deploy-fe-blue-green.yml
+++ b/.github/workflows/deploy-fe-blue-green.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare SSH key
         shell: bash
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare SSH key
         shell: bash

--- a/.github/workflows/deploy-k8s-fe-be.yml
+++ b/.github/workflows/deploy-k8s-fe-be.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout frontend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -89,7 +89,7 @@ jobs:
           echo "deploy_target=$DEPLOY_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Checkout backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.BACKEND_REPO }}
           ref: ${{ steps.vars.outputs.backend_ref }}
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Export AWS credentials for EKS auth
         shell: bash

--- a/.github/workflows/infra-rebuild-aws-bigbang.yml
+++ b/.github/workflows/infra-rebuild-aws-bigbang.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Guard confirmation
         run: |


### PR DESCRIPTION
## 변경 배경 / Background
- GitHub Actions run에서 actions/checkout@v4 및 actions/setup-node@v4가 Node.js 20 action runtime deprecation annotation을 발생시켰습니다.
- 2026년 runner 기본 runtime 전환 전에 official action runtime을 Node 24 기반으로 맞춰 CI 경고와 향후 호환성 리스크를 줄입니다.

## 주요 변경 사항 / Key changes
- .github/workflows 아래 8개 workflow의 actions/checkout 참조를 v6로 업데이트했습니다.
- actions/setup-node 참조를 v6로 업데이트했습니다.
- 애플리케이션 검증 기준인 node-version: 20, cache 설정, build/deploy command, trigger, secrets, environment 설정은 변경하지 않았습니다.

## 구현 방식 / Implementation details
- workflow YAML에서 official GitHub action version만 mechanical update했습니다.
- setup-node의 명시적 cache: npm 설정을 유지해 dependency install semantics가 바뀌지 않도록 했습니다.

## 영향 범위 / Impact
- Frontend CI, ECS/EC2/Kubernetes deploy workflow, self-hosted EC2 compose workflow의 action runtime 호환성에 영향이 있습니다.
- 애플리케이션 코드와 runtime behavior에는 영향이 없습니다.

## 테스트 및 검증 / Test & Validation
- Ruby YAML parser로 모든 workflow 로드 확인
- git diff --check 통과
- node --test tests/*.test.js 통과, 46 pass
- fork develop Frontend CI success: https://github.com/sungjin9288/2-sungjin-community-fe/actions/runs/25645259092

## 참고 사항 / Notes
- 수동 deploy workflow는 dispatch하지 않았으므로 self-hosted deploy runner의 실제 배포 job 실행 검증은 별도 단계로 남겨둡니다.